### PR TITLE
feat(useGrid): fallback size when containerWidth is 0

### DIFF
--- a/src/useGrid.js
+++ b/src/useGrid.js
@@ -211,7 +211,13 @@ export default function useGrid({ locale, month: currentMonth, onMonthChange, tr
   useEffect(() => {
     const handleResize = () => {
       const containerElement = containerElementRef.current
-      const containerWidth = containerElement.offsetWidth
+      let containerWidth = containerElement.offsetWidth
+
+      // Element is not rendered yet. Therefore, a fallback size must be provided
+      if (containerWidth === 0) {
+        containerWidth = Math.min(window.innerWidth, 548)
+      }
+
       const cellWidth = containerWidth / 7
       let newCellHeight = 1
       let wide = false


### PR DESCRIPTION
Closes #37 

I tried to write a unit test for `useGrid` but it fails since the returned `ref` must be place somewhere:

```js
import { renderHook } from '@testing-library/react-hooks'
import { enGB } from 'date-fns/locale'
import useGrid from '../src/useGrid'

describe('useGrid', () => {
  test('should have cellHeight greated than 6px', () => {
    const { result } = renderHook(() => useGrid({ locale: enGB, onMonthChange: () => {}, transitionDuration: 300 }))

    expect(result.current.cellHeight).toBeGreaterThan(6)
  })
})
```
I also tried [toHaveAttribute](https://spectrum.chat/testing-library/general/recommended-way-of-verifying-an-attribute~2409ec2d-5445-4cb4-bb75-49baaef26eb5?m=MTU0MzUxOTY4MzI3MQ==) from `jest-dom` with no success.

It seems to solve the problem tho, I tested manually across different devices.

If you have a suggestion regarding the test, I can update the PR before merging.
