### PR TITLE
Exports types useDateInput

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,3 +97,21 @@ declare module "react-nice-dates" {
     props: DateRangePickerCalendarProps
   ): JSX.Element;
 }
+
+export function useDateInput({
+  date,
+  format,
+  locale,
+  minimumDate,
+  maximumDate,
+  onDateChange,
+  validate
+}: {
+  date?: Date,
+  format?: string,
+  locale: Locale,
+  minimumDate?: Date,
+  maximumDate?: Date,
+  onDateChange?: (date: Date) => void,
+  validate?: (date: Date) => boolean,
+}): any


### PR DESCRIPTION
This PR addresses the issue where `useDateInput` types are not exported resulting in the following Typescript error:
> Module '"react-nice-dates"' has no exported member `useDateInput`