### PR TITLE
Use stand-alone month name localizer

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -55,7 +55,7 @@ export default function CalendarDay({
       style={{ height }}
     >
       {dayOfMonth === 1 && (
-        <span className='nice-dates-day_month'>{format(date, 'MMMM', { locale }).substring(0, 3)}</span>
+        <span className='nice-dates-day_month'>{format(date, 'LLLL', { locale }).substring(0, 3)}</span>
       )}
       <span className='nice-dates-day_date'>{dayOfMonth}</span>
     </span>

--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -55,7 +55,7 @@ export default function CalendarDay({
       style={{ height }}
     >
       {dayOfMonth === 1 && (
-        <span className='nice-dates-day_month'>{format(date, 'LLLL', { locale }).substring(0, 3)}</span>
+        <span className='nice-dates-day_month'>{format(date, 'LLL', { locale })}</span>
       )}
       <span className='nice-dates-day_date'>{dayOfMonth}</span>
     </span>

--- a/src/CalendarNavigation.js
+++ b/src/CalendarNavigation.js
@@ -25,7 +25,7 @@ export default function CalendarNavigation({ locale, month, minimumDate, maximum
       />
 
       <span className='nice-dates-navigation_current'>
-        {format(month, getYear(month) === getYear(new Date()) ? 'MMMM' : 'MMMM yyyy', { locale })}
+        {format(month, getYear(month) === getYear(new Date()) ? 'LLLL' : 'LLLL yyyy', { locale })}
       </span>
 
       <a

--- a/test/Calendar.test.js
+++ b/test/Calendar.test.js
@@ -13,7 +13,7 @@ describe('Calendar', () => {
 
     const today = new Date()
     const dayShortName = format(today, 'eee', { locale })
-    const monthName = format(today, 'MMMM', { locale })
+    const monthName = format(today, 'LLLL', { locale })
     const monthShortName = format(today, 'MMM', { locale })
 
     expect(getByText(dayShortName)).toBeInTheDocument()

--- a/test/DatePicker.test.js
+++ b/test/DatePicker.test.js
@@ -58,7 +58,7 @@ describe('DatePicker', () => {
 
   it('should display pre-selected date’s month on initial render', () => {
     const pastDate = subMonths(new Date(), 1)
-    const monthName = format(pastDate, 'MMMM', { locale })
+    const monthName = format(pastDate, 'LLLL', { locale })
 
     const { getByText } = render(
       <DatePicker locale={locale} date={pastDate}>

--- a/test/DatePickerCalendar.test.js
+++ b/test/DatePickerCalendar.test.js
@@ -30,7 +30,7 @@ describe('DatePickerCalendar', () => {
 
   it('should display pre-selected date’s month on initial render', () => {
     const pastDate = subMonths(new Date(), 1)
-    const monthName = format(pastDate, 'MMMM', { locale })
+    const monthName = format(pastDate, 'LLLL', { locale })
 
     const { getByText } = render(<DatePickerCalendar locale={locale} date={pastDate} />)
 

--- a/test/DateRangePicker.test.js
+++ b/test/DateRangePicker.test.js
@@ -69,7 +69,7 @@ describe('DateRangePicker', () => {
   it('should display pre-selected start date’s month on initial render', () => {
     const today = new Date()
     const pastDate = subMonths(today, 1)
-    const monthName = format(pastDate, 'MMMM', { locale })
+    const monthName = format(pastDate, 'LLLL', { locale })
 
     const { getByText } = render(
       <DateRangePicker locale={locale} startDate={pastDate} endDate={today}>
@@ -82,7 +82,7 @@ describe('DateRangePicker', () => {
 
   it('should display pre-selected end date’s month on initial render', () => {
     const pastDate = subMonths(new Date(), 1)
-    const monthName = format(pastDate, 'MMMM', { locale })
+    const monthName = format(pastDate, 'LLLL', { locale })
 
     const { getByText } = render(
       <DateRangePicker locale={locale} endDate={pastDate}>

--- a/test/DateRangePickerCalendar.test.js
+++ b/test/DateRangePickerCalendar.test.js
@@ -81,7 +81,7 @@ describe('DateRangePickerCalendar', () => {
   it('should display pre-selected start date’s month on initial render', () => {
     const today = new Date()
     const pastDate = subMonths(today, 1)
-    const monthName = format(pastDate, 'MMMM', { locale })
+    const monthName = format(pastDate, 'LLLL', { locale })
 
     const { getByText } = render(<DateRangePickerCalendar locale={locale} startDate={pastDate} endDate={today} />)
 
@@ -90,7 +90,7 @@ describe('DateRangePickerCalendar', () => {
 
   it('should display pre-selected end date’s month on initial render', () => {
     const pastDate = subMonths(new Date(), 1)
-    const monthName = format(pastDate, 'MMMM', { locale })
+    const monthName = format(pastDate, 'LLLL', { locale })
 
     const { getByText } = render(<DateRangePickerCalendar locale={locale} endDate={pastDate} />)
 


### PR DESCRIPTION
This pull request addresses an issue with displayed month name in some locales, namely languages in which a month's name can change depending on the context. More information available in ["Formatting localizers" section in date-fns l18n contribution guide](https://date-fns.org/v2.15.0/docs/I18n-Contribution-Guide#formatting-localizers).

Also note that in [CalendarDay.js:58](https://github.com/mariczne/react-nice-dates/blob/0ac76dc910207696134bd3fde2c6491891a9fba8/src/CalendarDay.js#L58) date-fns already provides a shorter formatting pattern `"LLL"` which could be used instead of a substring:
```jsx
<span className='nice-dates-day_month'>{format(date, 'LLL', { locale })}</span>
```
This, however, would insert a dot following the abbreviated month name in some languages (like Russian):
![Screenshot_20200810_141654](https://user-images.githubusercontent.com/35366016/89782130-f9808600-db14-11ea-9f0f-71f6b2dcaf81.png)
I was not sure if this would be intended behaviour, so I left it out.

Thanks for a very useful library!