### PR TITLE
Convert start/finish focus const to DateRangeFocus enum for TS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,10 @@ declare module "react-nice-dates" {
     format?: string;
   }
 
-  type DateRangeFocus = 'startDate' | 'endDate';
+  export enum DateRangeFocus {
+    startDate = 'startDate',
+    endDate = 'endDate'
+  }
 
   interface DateRangePickerChildrenProps {
     startDateInputProps: InputProps;


### PR DESCRIPTION
Fixes #42 

Exports a `DateRangeFocus` enum for use in typescript.

Eg:

```typescript
import {DateRangePicker, DateRangeFocus} from 'react-nice-dates'

return <DateRangePicker {...args}>{
    ({focus}) => <p>{focus == DateRangeFocus.startDate ? "Start is focused" : "End is focused"}</p>
}</DateRangePicker>
```