### PR TITLE
Revert "Convert start/finish focus const to DateRangeFocus enum for TS"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,10 +48,7 @@ declare module "react-nice-dates" {
     format?: string;
   }
 
-  export enum DateRangeFocus {
-    startDate = 'startDate',
-    endDate = 'endDate'
-  }
+  type DateRangeFocus = 'startDate' | 'endDate';
 
   interface DateRangePickerChildrenProps {
     startDateInputProps: InputProps;


### PR DESCRIPTION
Hey @hernansartorio, sorry to reverse the PR, but I made a bad assumption for javascript files with the typing file - enums don't work very well. It won't break anyone's existing projects, but it's best to revert hernansartorio/react-nice-dates#46 and leave it how it was. 

Sorry for the inconvenience. 