### PR TITLE
Show year in month

### DIFF
--- a/src/CalendarNavigation.js
+++ b/src/CalendarNavigation.js
@@ -25,7 +25,7 @@ export default function CalendarNavigation({ locale, month, minimumDate, maximum
       />
 
       <span className='nice-dates-navigation_current'>
-        {format(month, getYear(month) === getYear(new Date()) ? 'LLLL' : 'LLLL yyyy', { locale })}
+        {format(month, 'LLLL yyyy', { locale })}
       </span>
 
       <a


### PR DESCRIPTION
### Description

It'd be nice to always show the year for the given month in the calendar navigation to avoid confusion and limit the possibility of the Date failing.