### PR TITLE
add date-string attribute to <CalendarDay/>s

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -53,6 +53,7 @@ export default function CalendarDay({
       onMouseLeave={handleMouseLeave}
       onTouchEnd={handleClick}
       style={{ height }}
+      data-date-string={format(date, 'yyyy-MM-dd')}
     >
       {dayOfMonth === 1 && (
         <span className='nice-dates-day_month'>{format(date, 'LLL', { locale })}</span>


### PR DESCRIPTION
I need to control this component is a Jest test, there was no way I could currently think of to click on a certain day on the calendar. This PR adds a data attribute that Jest can query for.